### PR TITLE
dashboard: allow configuring multiple grafana host

### DIFF
--- a/roles/ceph-dashboard/tasks/config_grafana_layouts.yaml
+++ b/roles/ceph-dashboard/tasks/config_grafana_layouts.yaml
@@ -1,0 +1,13 @@
+---
+- name: set grafana url
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ grafana_server_addr }}:{{ grafana_port }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+
+- name: inject grafana dashboard layouts
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard grafana dashboards update"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  when: containerized_deployment | bool

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -94,12 +94,6 @@
   changed_when: false
   until: ac_result.rc == 0
 
-- name: set grafana url
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ grafana_server_addr }}:{{ grafana_port }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  changed_when: false
-
 - name: set grafana api user
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-username {{ grafana_admin_user }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -123,6 +117,11 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
+
+- include_tasks: config_grafana_layouts.yml
+  with_items: '{{ grafana_server_addrs }}'
+  vars:
+    grafana_server_addr: '{{ item }}'
 
 - name: dashboard object gateway management frontend
   when: groups.get(rgw_group_name, []) | length > 0
@@ -219,13 +218,6 @@
       with_items: "{{ groups[iscsi_gw_group_name] }}"
       run_once: true
       when: ip_version == 'ipv6'
-
-- name: inject grafana dashboard layouts
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard grafana dashboards update"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  changed_when: false
-  when: containerized_deployment | bool
 
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mgr module disable dashboard"

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -1,3 +1,4 @@
+---
 - name: set grafana_server_addr fact - ipv4
   set_fact:
     grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
@@ -16,20 +17,20 @@
     - dashboard_enabled | bool
     - inventory_hostname in groups[grafana_server_group_name]
 
-- name: set grafana_server_addr fact - ipv4 - (external instance)
+- name: set grafana_server_addrs fact - ipv4
   set_fact:
-    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first]) | unique }}"
+  with_items: "{{ groups.get(grafana_server_group_name, []) }}"
   when:
     - groups.get(grafana_server_group_name, []) | length > 0
     - ip_version == 'ipv4'
     - dashboard_enabled | bool
-    - inventory_hostname not in groups[grafana_server_group_name]
 
-- name: set grafana_server_addr fact - ipv6 - (external instance)
+- name: set grafana_server_addrs fact - ipv6
   set_fact:
-    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap]) | unique }}"
+  with_items: "{{ groups.get(grafana_server_group_name, []) }}"
   when:
     - groups.get(grafana_server_group_name, []) | length > 0
     - ip_version == 'ipv6'
     - dashboard_enabled | bool
-    - inventory_hostname not in groups[grafana_server_group_name]


### PR DESCRIPTION
When using multiple grafana hosts then we set the grafana URL
and push the dashboard layout to a single node.

grafana_server_addrs is the list of all grafana nodes and used during
the ceph-dashboard role (on mgr/mon nodes).
grafana_server_addr is the current grafana node used during the
ceph-grafana and ceph-prometheus role (on grafana-server nodes).

We don't have the grafana_server_addr fact duplication code between
external vs collocated nodes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1784011

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>